### PR TITLE
Update demo links in README and configuration files

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -22,6 +22,8 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
+  issues: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -106,5 +108,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '🚀 Demo build completed successfully! The demo will be available at the `/demo/` path once deployed to the main branch.'
+              body: '🚀 Demo build completed successfully! The demo will be available at https://liftledger.yukai.dev/ once deployed to the main branch.'
             })

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Experience LiftLedger with our interactive demo that features:
 - Real-time linting and error detection
 - Example templates and scenarios
 
-**[View Demo →](https://liftledger.yukai.dev/demo/)**
+**[View Demo →](https://liftledger.yukai.dev/)**
 
 The demo showcases the LiftLedger format with CodeMirror integration and provides instant feedback on your LiftLedger entries.
 

--- a/packages/liftledger-demo/README.md
+++ b/packages/liftledger-demo/README.md
@@ -54,7 +54,7 @@ pnpm preview
 ### Live Demo
 
 The demo is automatically deployed to GitHub Pages and available at:
-**[https://liftledger.yukai.dev/demo/](https://liftledger.yukai.dev/demo/)**
+**[https://liftledger.yukai.dev/](https://liftledger.yukai.dev/)**
 
 The deployment happens automatically when changes are pushed to the main branch.
 

--- a/packages/liftledger-demo/vite.config.js
+++ b/packages/liftledger-demo/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: process.env.NODE_ENV === 'production' ? '/demo/' : '/',
+  base: '/',
   server: {
     port: 3000,
     open: true


### PR DESCRIPTION
Update the demo links in README files to remove the '/demo/' path and adjust the base configuration for production to reflect this change.